### PR TITLE
FIX: renamed the deprecated workflow.mco to workflow.mco_model

### DIFF
--- a/force_nevergrad/mco/tests/test_ng_mco.py
+++ b/force_nevergrad/mco/tests/test_ng_mco.py
@@ -71,7 +71,7 @@ class TestMCO(TestCase, UnittestTools):
         evaluator = WorkflowEvaluator(
             workflow=Workflow(), workflow_filepath="whatever"
         )
-        evaluator.workflow.mco = model
+        evaluator.workflow.mco_model = model
         kpis = [DataValue(value=1), DataValue(value=2)]
         with self.assertTraitChanges(mco, "event", count=61):
             with mock.patch(


### PR DESCRIPTION
This PR fixes the reference to `Workflow.mco` which was changed in [#257](https://github.com/force-h2020/force-bdss/pull/257).