### PR TITLE
MAINT: Nevergrad version update

### DIFF
--- a/ci/__main__.py
+++ b/ci/__main__.py
@@ -6,7 +6,7 @@ import subprocess
 DEFAULT_PYTHON_VERSION = "3.6"
 PYTHON_VERSIONS = ["3.6"]
 
-_nevergrad_stable_commit = "589eefa3dd28d3013cdefe3ebf1514e5a17f2103"
+_nevergrad_stable_commit = "5026eea6c44b83b114bcdb55f6254104d793e927"
 
 ADDITIONAL_CORE_DEPS = [
 

--- a/ci/__main__.py
+++ b/ci/__main__.py
@@ -6,7 +6,7 @@ import subprocess
 DEFAULT_PYTHON_VERSION = "3.6"
 PYTHON_VERSIONS = ["3.6"]
 
-_nevergrad_stable_commit = "ba2c0217a043178adf9fe9f4bd52bbbfce97bfaa"
+_nevergrad_stable_commit = "589eefa3dd28d3013cdefe3ebf1514e5a17f2103"
 
 ADDITIONAL_CORE_DEPS = [
 

--- a/force_nevergrad/engine/nevergrad_engine.py
+++ b/force_nevergrad/engine/nevergrad_engine.py
@@ -138,9 +138,9 @@ class NevergradOptimizerEngine(BaseOptimizerEngine):
             ng_optimizer.tell(x, volume)
 
             if self.verbose_run:
-                yield x.args, value, [1] * len(self.kpis)
+                yield x.args, value
 
         if not self.verbose_run:
             for point, value in f._points:
                 value = self._minimization_score(value)
-                yield point[0], value, [1] * len(self.kpis)
+                yield point[0], value

--- a/force_nevergrad/engine/nevergrad_engine.py
+++ b/force_nevergrad/engine/nevergrad_engine.py
@@ -89,7 +89,7 @@ class NevergradOptimizerEngine(BaseOptimizerEngine):
         instrumentation = [
             self._create_instrumentation_variable(p) for p in parameters
         ]
-        return ng.Instrumentation(*instrumentation)
+        return ng.p.Instrumentation(*instrumentation)
 
     def _get_kpi_bounds(self):
         """ Assemble optimization bounds on KPIs, provided by
@@ -127,7 +127,7 @@ class NevergradOptimizerEngine(BaseOptimizerEngine):
         instrumentation = self._assemble_instrumentation()
         instrumentation.random_state.seed(12)
         ng_optimizer = ng.optimizers.registry[self.algorithms](
-            instrumentation=instrumentation, budget=self.budget
+            parametrization=instrumentation, budget=self.budget
         )
         for _ in range(ng_optimizer.budget):
             x = ng_optimizer.ask()

--- a/force_nevergrad/engine/tests/test_nevergrad_engine.py
+++ b/force_nevergrad/engine/tests/test_nevergrad_engine.py
@@ -113,7 +113,7 @@ class TestNevergradOptimizerEngine(TestCase):
 
     def test__create_instrumentation(self):
         instrumentation = self.optimizer._assemble_instrumentation()
-        self.assertIsInstance(instrumentation, ng.Instrumentation)
+        self.assertIsInstance(instrumentation, ng.p.Instrumentation)
         self.assertEqual(
             len(self.optimizer.parameters), len(instrumentation.args)
         )

--- a/force_nevergrad/engine/tests/test_nevergrad_engine.py
+++ b/force_nevergrad/engine/tests/test_nevergrad_engine.py
@@ -152,4 +152,3 @@ class TestNevergradOptimizerEngine(TestCase):
         for optimized_data in self.mocked_optimizer.optimize():
             self.assertEqual(4, len(optimized_data[0]))
             self.assertEqual(2, len(optimized_data[1]))
-            self.assertListEqual([1, 1], optimized_data[2])

--- a/force_nevergrad/mco/ng_mco.py
+++ b/force_nevergrad/mco/ng_mco.py
@@ -34,17 +34,15 @@ class NevergradMCO(BaseMCO):
         for (
             optimal_point,
             optimal_kpis,
-            scaled_weights,
         ) in optimizer.optimize():
             # When there is new data, this operation informs the system that
             # new data has been received. It must be a dictionary as given.
             readable_points = [
                 label_dict[v] if v in label_dict else v for v in optimal_point
             ]
-            self.notify_new_point(
+            model.notify_progress_event(
                 [DataValue(value=v) for v in readable_points],
                 [DataValue(value=v) for v in optimal_kpis],
-                scaled_weights,
             )
 
 

--- a/force_nevergrad/mco/tests/test_ng_mco.py
+++ b/force_nevergrad/mco/tests/test_ng_mco.py
@@ -3,7 +3,6 @@ from unittest import TestCase, mock
 from traits.testing.unittest_tools import UnittestTools
 
 from force_bdss.api import (
-    WorkflowEvaluator,
     KPISpecification,
     Workflow,
     DataValue,
@@ -14,7 +13,7 @@ from force_bdss.api import (
     ListedMCOParameter,
     RangedMCOParameter,
     CategoricalMCOParameterFactory,
-    CategoricalMCOParameter
+    CategoricalMCOParameter,
 )
 
 from force_nevergrad.nevergrad_plugin import NevergradPlugin
@@ -68,14 +67,12 @@ class TestMCO(TestCase, UnittestTools):
         model.parameters = self.parameters
         model.kpis = [KPISpecification(), KPISpecification()]
 
-        evaluator = WorkflowEvaluator(
-            workflow=Workflow(), workflow_filepath="whatever"
-        )
-        evaluator.workflow.mco_model = model
+        workflow = Workflow()
+        workflow.mco_model = model
         kpis = [DataValue(value=1), DataValue(value=2)]
-        with self.assertTraitChanges(mco, "event", count=61):
+        with self.assertTraitChanges(model, "event", count=61):
             with mock.patch(
                 "force_bdss.api.Workflow.execute", return_value=kpis
             ) as mock_exec:
-                mco.run(evaluator)
+                mco.run(workflow)
                 self.assertEqual(61, mock_exec.call_count)


### PR DESCRIPTION
### Summary

This PR updates `nevergrad` to version 0.3.2 and uses the most recent available commit on the `nevergrad` master branch.

### Done
- Updated `MCO` class to account for BDSS API changes
- Updated `OptimizerEngine` to account for `nevergrad` API changes