### PR TITLE
DEV: Vector parameters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ before_install:
     - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then export PATH=${HOME}/edm/bin:${PATH} ; fi
     - if [[ ${TRAVIS_OS_NAME} == "osx" ]]; then export PATH="${PATH}:/usr/local/bin" ; fi
     - edm install -y --version 3.6 click setuptools
-    - git clone git://github.com/force-h2020/force-bdss.git
+    - git clone git://github.com/force-h2020/force-bdss.git -b dev/vector-mco-parameter
     - pushd force-bdss && edm run -- python -m ci build-env && edm run -- python -m ci install && popd
 script:
     - edm run -- python -m ci install

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ before_install:
     - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then export PATH=${HOME}/edm/bin:${PATH} ; fi
     - if [[ ${TRAVIS_OS_NAME} == "osx" ]]; then export PATH="${PATH}:/usr/local/bin" ; fi
     - edm install -y --version 3.6 click setuptools
-    - git clone git://github.com/force-h2020/force-bdss.git -b dev/vector-mco-parameter
+    - git clone git://github.com/force-h2020/force-bdss.git
     - pushd force-bdss && edm run -- python -m ci build-env && edm run -- python -m ci install && popd
 script:
     - edm run -- python -m ci install

--- a/force_nevergrad/engine/nevergrad_engine.py
+++ b/force_nevergrad/engine/nevergrad_engine.py
@@ -56,9 +56,10 @@ class NevergradOptimizerEngine(BaseOptimizerEngine):
             mid_point = parameter.initial_value
             try:
                 _ = parameter.dimension
-                parameter_type = ng.p.Array
             except AttributeError:
                 parameter_type = ng.p.Scalar
+            else:
+                parameter_type = ng.p.Array
             return parameter_type(init=mid_point).set_bounds(
                 parameter.lower_bound, parameter.upper_bound, method="arctan"
             )

--- a/force_nevergrad/engine/nevergrad_engine.py
+++ b/force_nevergrad/engine/nevergrad_engine.py
@@ -54,7 +54,12 @@ class NevergradOptimizerEngine(BaseOptimizerEngine):
             parameter, "upper_bound"
         ):
             mid_point = parameter.initial_value
-            return ng.p.Scalar(mid_point).set_bounds(
+            try:
+                _ = parameter.dimension
+                parameter_type = ng.p.Array
+            except AttributeError:
+                parameter_type = ng.p.Scalar
+            return parameter_type(init=mid_point).set_bounds(
                 parameter.lower_bound, parameter.upper_bound, method="arctan"
             )
         elif hasattr(parameter, "value"):

--- a/force_nevergrad/mco/ng_mco_factory.py
+++ b/force_nevergrad/mco/ng_mco_factory.py
@@ -3,6 +3,7 @@ from force_bdss.api import (
     FixedMCOParameterFactory,
     ListedMCOParameterFactory,
     RangedMCOParameterFactory,
+    RangedVectorMCOParameterFactory,
     CategoricalMCOParameterFactory,
     BaseMCOCommunicator
 )
@@ -43,4 +44,5 @@ class NevergradMCOFactory(BaseMCOFactory):
             ListedMCOParameterFactory,
             RangedMCOParameterFactory,
             CategoricalMCOParameterFactory,
+            RangedVectorMCOParameterFactory
         ]

--- a/force_nevergrad/mco/tests/test_ng_mco.py
+++ b/force_nevergrad/mco/tests/test_ng_mco.py
@@ -14,6 +14,8 @@ from force_bdss.api import (
     RangedMCOParameter,
     CategoricalMCOParameterFactory,
     CategoricalMCOParameter,
+    RangedVectorMCOParameter,
+    RangedVectorMCOParameterFactory
 )
 
 from force_nevergrad.nevergrad_plugin import NevergradPlugin
@@ -45,6 +47,11 @@ class TestMCO(TestCase, UnittestTools):
                 upper_bound=1.5,
                 n_samples=3,
             ),
+            RangedVectorMCOParameter(
+                mock.Mock(spec=RangedVectorMCOParameterFactory),
+                upper_bound=[1.5],
+                n_samples=3,
+            )
         ]
         self.model.parameters = self.parameters
 
@@ -58,7 +65,7 @@ class TestMCO(TestCase, UnittestTools):
         self.assertEqual("nevergrad_mco", self.factory.get_identifier())
         self.assertIs(self.factory.get_model_class(), NevergradMCOModel)
         self.assertIs(self.factory.get_optimizer_class(), NevergradMCO)
-        self.assertEqual(4, len(self.factory.get_parameter_factory_classes()))
+        self.assertEqual(5, len(self.factory.get_parameter_factory_classes()))
 
     def test_simple_run(self):
         mco = self.factory.create_optimizer()


### PR DESCRIPTION
This PR closes #11 

### Summary

We add an additional check when creating a `nevergrad` instrumentation: if the "bounded" parameters implements a `dimension` attribute, it is a `RangedVector` parameter, and therefore we create a `ng.p.Array` object instead of `ng.p.Scalar`.
