### PR TITLE
DEV: Release of Force Nevergrad Version 0.1.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,0 +1,26 @@
+FORCE Nevergrad Plugin Changelog
+================================
+
+Release 0.1.0
+-------------
+
+Released: 12/03/2020
+
+Release notes
+~~~~~~~~~~~~~
+
+Version 0.1.0 is the inital release of the ``force-bdss-plugin-nevergrad`` package.
+
+The following people contributed code changes for this release:
+
+* Frank Longford
+* Petr Kungurtsev
+
+Features
+~~~~~~~~
+* BDSS plugin ``NevergradPlugin`` (#4), contributing with stand alone BDSS objects that can be
+  used and customised 'out-of-the-box'
+* Pinned to Nevergrad stable commit on master branch, using API from 0.3.2 (#4, #8)
+* One BDSS ``OptimizerEngine`` subclass (#4, #13): ``NevergradOptimizerEngine``
+* One BDSS ``MCO`` subclass (#4, #5, #10): ``NevergradMCO``
+* Documentation included describing gradient free methods and Nevergrad API (#12)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,7 @@ Version 0.1.0 is the inital release of the ``force-bdss-plugin-nevergrad`` packa
 
 The following people contributed code changes for this release:
 
+* Corran Webster
 * Frank Longford
 * Petr Kungurtsev
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ FORCE Nevergrad Plugin Changelog
 Release 0.1.0
 -------------
 
-Released: 12/03/2020
+Released: 12 Mar 2020
 
 Release notes
 ~~~~~~~~~~~~~

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import os
 from setuptools import setup, find_packages
 
-VERSION = "0.1.0.dev0"
+VERSION = "0.1.0"
 
 
 # Read description
@@ -32,6 +32,6 @@ setup(
         },
     packages=find_packages(),
     install_requires=[
-            "force_bdss >= 0.3.0",
+            "force_bdss >= 0.4.0",
         ]
 )


### PR DESCRIPTION
This PR announces the release of version 0.1.0 of the Force Nevergrad plugin.

Full change log can be found in `CHANGES.rst`