### PR TITLE
DEV: Bump to Version 0.2.0.dev

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,9 @@
 FORCE Nevergrad Plugin Changelog
 ================================
 
+Release 0.2.0
+-------------
+
 Release 0.1.0
 -------------
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import os
 from setuptools import setup, find_packages
 
-VERSION = "0.1.0"
+VERSION = "0.2.0.dev0"
 
 
 # Read description


### PR DESCRIPTION
This PR bumps the plugin to development version `0.2.0.dev0`