### PR TITLE
FIX: User raw KPI upper bound for Target objective

### DIFF
--- a/force_nevergrad/mco/ng_mco.py
+++ b/force_nevergrad/mco/ng_mco.py
@@ -30,11 +30,14 @@ class NevergradOptimizerEngine(AposterioriOptimizerEngine):
         # If KPI objective is to maximise the value, then use
         # the lower bound attribute. Otherwise use the upper
         # bound attribute
-        kpi_bounds = [
-            kpi.lower_bound
-            if kpi.objective == 'MAXIMISE' else kpi.upper_bound
-            for kpi in self.kpis
-        ]
+        kpi_bounds = []
+        for kpi in self.kpis:
+            if kpi.objective == 'MINIMISE':
+                kpi_bounds.append(kpi.upper_bound)
+            elif kpi.objective == 'MAXIMISE':
+                kpi_bounds.append(kpi.lower_bound)
+            elif kpi.objective == 'TARGET':
+                kpi_bounds.append(kpi.target_value + kpi.upper_bound)
 
         # Transform the raw KPI bounds to the minimization score
         score_upper_bounds = self._minimization_score(kpi_bounds)

--- a/force_nevergrad/mco/ng_mco.py
+++ b/force_nevergrad/mco/ng_mco.py
@@ -36,7 +36,7 @@ class NevergradOptimizerEngine(AposterioriOptimizerEngine):
                 kpi_bounds.append(kpi.upper_bound)
             elif kpi.objective == 'MAXIMISE':
                 kpi_bounds.append(kpi.lower_bound)
-            elif kpi.objective == 'TARGET':
+            else:
                 kpi_bounds.append(kpi.target_value + kpi.upper_bound)
 
         # Transform the raw KPI bounds to the minimization score

--- a/force_nevergrad/mco/tests/test_ng_mco.py
+++ b/force_nevergrad/mco/tests/test_ng_mco.py
@@ -52,8 +52,9 @@ class TestNevergradOptimizerEngine(TestCase):
 
         kpis[0].objective = "TARGET"
         kpis[0].target_value = 1.5
+        kpis[0].upper_bound = 1.0
         self.assertListEqual(
-            [2.5, None], engine.score_upper_bounds())
+            [1.0, None], engine.score_upper_bounds())
 
 
 class TestMCO(TestCase, UnittestTools):

--- a/force_nevergrad/mco/tests/test_ng_mco.py
+++ b/force_nevergrad/mco/tests/test_ng_mco.py
@@ -53,9 +53,8 @@ class TestNevergradOptimizerEngine(TestCase):
         kpis[0].objective = "TARGET"
         kpis[0].target_value = 1.5
         self.assertListEqual(
-            [1.0, None], engine.score_upper_bounds())
+            [2.5, None], engine.score_upper_bounds())
 
-        print(engine.score_upper_bounds())
 
 
 class TestMCO(TestCase, UnittestTools):

--- a/force_nevergrad/mco/tests/test_ng_mco.py
+++ b/force_nevergrad/mco/tests/test_ng_mco.py
@@ -56,7 +56,6 @@ class TestNevergradOptimizerEngine(TestCase):
             [2.5, None], engine.score_upper_bounds())
 
 
-
 class TestMCO(TestCase, UnittestTools):
     def setUp(self):
         self.plugin = NevergradPlugin()


### PR DESCRIPTION
PR #23 introduced upper bound assignments for KPIs, but did not include appropriate handling for KPIs that are required to meet a target objective.

This small fix assumes the `KPISpecification.upper_bound` attributes are an upper bound on the 'distance from target value`, as used in https://github.com/force-h2020/force-wfmanager/pull/396