### PR TITLE
ENH: Include verbose mode in NevergradMultiOptimizer class

### DIFF
--- a/force_nevergrad/engine/nevergrad_optimizers.py
+++ b/force_nevergrad/engine/nevergrad_optimizers.py
@@ -2,6 +2,7 @@
 #  All rights reserved.
 
 from functools import partial
+import logging
 
 import nevergrad as ng
 from nevergrad.functions import MultiobjectiveFunction
@@ -26,6 +27,8 @@ from .parameter_translation import (
     translate_ng_to_mco
 )
 
+
+log = logging.getLogger(__name__)
 
 ALGORITHMS_KEYS = ng.optimizers.registry.keys()
 
@@ -300,7 +303,9 @@ class NevergradMultiOptimizer(HasStrictTraits):
         ob_func = self.get_multiobjective_function(ng_func, upper_bounds)
 
         # Perform all calculations in the budget
-        for _ in range(self.budget):
+        for index in range(self.budget):
+            log.info("Doing  MCO run # {} / {}".format(index, self.budget))
+
             # Generate and solve a new input point
             x, _ = _nevergrad_ask_tell(optimizer, ob_func)
 

--- a/force_nevergrad/engine/tests/test_nevergrad_optimizers.py
+++ b/force_nevergrad/engine/tests/test_nevergrad_optimizers.py
@@ -121,7 +121,7 @@ class TestNevergradOptimizer(TestCase):
     )
     @patch.object(
         NevergradMultiOptimizer,
-        '_estimate_upper_bounds',
+        '_calculate_upper_bounds',
         return_value=[10, 10]
     )
     def test_nevergrad_multi_optimizer(self, mock1, mock2, mock3):
@@ -171,15 +171,16 @@ class TestNevergradOptimizer(TestCase):
     def test_estimate_upper_bounds(self):
         optimizer = NevergradMultiOptimizer()
         ng_optimizer = optimizer.get_optimizer(self.params)
+        optimizer.upper_bounds = [None, None, 10]
 
-        upper_bounds = optimizer._estimate_upper_bounds(
+        upper_bounds = optimizer._calculate_upper_bounds(
             ng_optimizer, self.m_foo)
 
-        self.assertListEqual([1, 2, 3], upper_bounds)
+        self.assertListEqual([1, 2, 10], upper_bounds)
 
         optimizer.bound_sample = 5
         with patch(AGGREGATE_LOSS_PATH) as mock_loss:
-            optimizer._estimate_upper_bounds(
+            optimizer._calculate_upper_bounds(
                 ng_optimizer, self.m_foo)
             self.assertEqual(5, mock_loss.call_count)
 

--- a/force_nevergrad/engine/tests/test_nevergrad_optimizers.py
+++ b/force_nevergrad/engine/tests/test_nevergrad_optimizers.py
@@ -7,6 +7,7 @@ import numpy as np
 from functools import partial
 
 from force_nevergrad.engine.nevergrad_optimizers import (
+    _nevergrad_ask_tell,
     nevergrad_function,
     NevergradMultiOptimizer,
     NevergradScalarOptimizer,
@@ -17,6 +18,7 @@ from force_nevergrad.engine.parameter_translation import (
 )
 
 from force_nevergrad.tests.mock_classes.mock_optimizer import (
+    MockPoint,
     MockOptimizer,
     MockMultiObjectiveFunction
 )
@@ -25,9 +27,9 @@ from nevergrad.optimization.base import Optimizer
 from nevergrad.functions import MultiobjectiveFunction
 
 
-AGGREGATE_LOSS_PATH = (
+ASK_TELL_PATH = (
     'force_nevergrad.engine.nevergrad_optimizers'
-    '.MultiobjectiveFunction.compute_aggregate_loss')
+    '._nevergrad_ask_tell')
 
 
 class TestNevergradOptimizer(TestCase):
@@ -46,6 +48,24 @@ class TestNevergradOptimizer(TestCase):
         # nevergrad_function() can negate the objective in-place
         # and this doesn't change behaviour on another call.
         self.m_foo = Mock(side_effect=[[1, 2, 3] for _ in range(20)])
+
+    def test_nevergrad_ask_tell(self):
+
+        optimizer = MockOptimizer(params=self.params)
+        ob_func = MockMultiObjectiveFunction(params=self.params)
+
+        with patch.object(MockMultiObjectiveFunction,
+                          'compute_aggregate_loss') as mock_loss:
+
+            x, value = _nevergrad_ask_tell(optimizer, ob_func, no_bias=True)
+            self.assertListEqual([0, 1], x.args)
+            self.assertEqual(1, value)
+            mock_loss.assert_not_called()
+
+            x, value = _nevergrad_ask_tell(optimizer, ob_func)
+            self.assertListEqual([0, 1], x.args)
+            self.assertEqual(1, value)
+            mock_loss.assert_called()
 
     def test_nevergrad_function(self):
 
@@ -173,16 +193,22 @@ class TestNevergradOptimizer(TestCase):
         ng_optimizer = optimizer.get_optimizer(self.params)
         optimizer.upper_bounds = [None, None, 10]
 
-        upper_bounds = optimizer._calculate_upper_bounds(
-            ng_optimizer, self.m_foo)
+        with patch.object(MultiobjectiveFunction,
+                          'compute_aggregate_loss') as mock_loss:
+            upper_bounds = optimizer._calculate_upper_bounds(
+                ng_optimizer, self.m_foo)
 
-        self.assertListEqual([1, 2, 10], upper_bounds)
+            self.assertListEqual([1, 2, 10], upper_bounds)
+            mock_loss.assert_not_called()
 
         optimizer.bound_sample = 5
-        with patch(AGGREGATE_LOSS_PATH) as mock_loss:
+        with patch(ASK_TELL_PATH) as mock_func:
+            mock_func.return_value = (
+                MockPoint(args=[0, 1], kwargs={}), 1)
+
             optimizer._calculate_upper_bounds(
                 ng_optimizer, self.m_foo)
-            self.assertEqual(5, mock_loss.call_count)
+            self.assertEqual(5, mock_func.call_count)
 
     def test_get_optimizer(self):
 

--- a/force_nevergrad/mco/ng_mco.py
+++ b/force_nevergrad/mco/ng_mco.py
@@ -90,7 +90,6 @@ class NevergradMCO(BaseMCO):
                 in enumerate(engine.optimize(verbose_run=model.verbose_run)):
             # When there is new data, this operation informs the system that
             # new data has been received. It must be a dictionary as given.
-            log.info("Doing  MCO run # {}".format(index))
             model.notify_progress_event(
                 [DataValue(value=v) for v in optimal_point],
                 [DataValue(value=v) for v in optimal_kpis],

--- a/force_nevergrad/tests/mock_classes/mock_optimizer.py
+++ b/force_nevergrad/tests/mock_classes/mock_optimizer.py
@@ -32,10 +32,10 @@ class MockMultiObjectiveFunction:
         self.pareto_size = pareto_size
 
     def multiobjective_function(self, *args):
-        return 0
+        return 1
 
     def compute_aggregate_loss(self, *args, **kwargs):
-        return 0
+        return 1
 
     def pareto_front(self):
         return [(self.ng_params.args, self.ng_params.kwargs)]*self.pareto_size

--- a/force_nevergrad/tests/mock_classes/mock_optimizer.py
+++ b/force_nevergrad/tests/mock_classes/mock_optimizer.py
@@ -1,6 +1,10 @@
+from collections import namedtuple
+
 from force_nevergrad.engine.parameter_translation import (
     translate_mco_to_ng,
 )
+
+MockPoint = namedtuple('x', ['args', 'kwargs'])
 
 
 class MockOptimizer:
@@ -9,8 +13,16 @@ class MockOptimizer:
         self.ng_params = translate_mco_to_ng(params)
 
     def minimize(self, *vargs):
-
         return self.ng_params
+
+    def ask(self):
+        return MockPoint(
+            [x for x in range(len(self.ng_params))],
+            {}
+        )
+
+    def tell(self, x, volume):
+        return
 
 
 class MockMultiObjectiveFunction:
@@ -19,6 +31,11 @@ class MockMultiObjectiveFunction:
         self.ng_params = translate_mco_to_ng(params)
         self.pareto_size = pareto_size
 
-    def pareto_front(self):
+    def multiobjective_function(self, *args):
+        return 0
 
+    def compute_aggregate_loss(self, *args, **kwargs):
+        return 0
+
+    def pareto_front(self):
         return [(self.ng_params.args, self.ng_params.kwargs)]*self.pareto_size


### PR DESCRIPTION
This PR uses Nevergrad's ask and tell interface to allow all calculated KPI values to be reported back during the optimization process, rather than at the end of the MCO run. We also perform some refactoring to include the same routine when estimating KPI upper bounds.

The Pareto front is still returned at the end of the MCO if `verbose_run` is False, since this requires all values to be calculated first.